### PR TITLE
Add missing LinearAlgebra import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ ___
 ## Example
 
 ```julia
+julia> using LinearAlgebra
+
 julia> using SymToeplitzEigen
 
 julia> v = rand(10);


### PR DESCRIPTION
It seems like for me the LinearAlgebra package was not loaded automatically, and I could not run the example. Adding this line made it work for me, and perhaps other less experienced Julia users.